### PR TITLE
Add per-operation metric collector facility

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 0.9.4-beta
 * Moved Sync-over-Async versions of `TableContext` operations into `namespace FSharp.AWS.DynamoDB.Scripting`
+* Added `?collector` parameter to each operation on `TableContext` to enable separated collection for concurrent requests
 
 ### 0.9.3-beta
 * Added `RequestMetrics` record type


### PR DESCRIPTION
Adds the facility to supply a metrics collector at the individual operation level
This enables one to deterministically attribute metrics to individual calls on a given TableContext